### PR TITLE
snapshot: Add charm release pipeline workflow (#5)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,42 @@
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Release to latest/edge
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  ci-tests:
+    uses: ./.github/workflows/ci.yaml
+
+  release-to-charmhub:
+    name: Release to CharmHub
+    needs:
+      - ci-tests
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@2.2.0
+        id: channel
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@2.2.0
+        with:
+          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          channel: "${{ steps.channel.outputs.name }}"

--- a/src/interface_slurmd.py
+++ b/src/interface_slurmd.py
@@ -216,7 +216,6 @@ def ensure_unique_partitions(partitions):
 
     partitions_tmp = copy.deepcopy(partitions)
     for partition in partitions_tmp:
-
         partition_tmp = copy.deepcopy(partition)
         partitions.remove(partition)
 


### PR DESCRIPTION
## Description

This pull request adds a charm release pipeline workflow for the slurmctld operator.

__Important!__ Make sure you check the following before merging this pull request!:

* Repository secret name matches the one in the release.yaml: `CHARMCRAFT_AUTH`
* Repository settings under actions -> general -> workflow permissions is set to enable read and write permissions.

## How was the code tested?

Release workflow tested on a test charm on GitHub which successfully released to Charmhub.

## Co-contributors

@dvdgomez and @jaimesouza 

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.

## Miscellaneous

* There was a lint fix that needed to be applied to the `interface_slurmd.py` file so that the lint checks would pass in the CI pipeline.
