### PR TITLE
bugfix: Fix integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,6 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
-          # Juju channel should eventually be updated to 3.0/stable
-          juju-channel: 2.9/stable
+          juju-channel: 3.1/stable
       - name: Run tests
         run: tox -e integration

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -31,7 +31,8 @@ SERIES = ["focal"]
 SLURMCTLD = "slurmctld"
 SLURMD = "slurmd"
 SLURMDBD = "slurmdbd"
-DATABASE = "percona-cluster"
+DATABASE = "mysql"
+ROUTER = "mysql-router"
 
 
 @pytest.mark.abort_on_fail
@@ -68,11 +69,18 @@ async def test_build_and_deploy_against_edge(
             series=series,
         ),
         ops_test.model.deploy(
+            ROUTER,
+            application_name=f"{SLURMDBD}-{ROUTER}",
+            channel="dpe/edge",
+            num_units=1,
+            series=series,
+        ),
+        ops_test.model.deploy(
             DATABASE,
             application_name=DATABASE,
             channel="edge",
             num_units=1,
-            series="bionic",
+            series="jammy",
         ),
     )
     # Attach resources to charms.
@@ -81,7 +89,8 @@ async def test_build_and_deploy_against_edge(
     # Set integrations for charmed applications.
     await ops_test.model.relate(f"{SLURMCTLD}:{SLURMD}", f"{SLURMD}:{SLURMD}")
     await ops_test.model.relate(f"{SLURMCTLD}:{SLURMDBD}", f"{SLURMDBD}:{SLURMDBD}")
-    await ops_test.model.relate(f"{SLURMDBD}:db", f"{DATABASE}:db")
+    await ops_test.model.relate(f"{SLURMDBD}-{ROUTER}:backend-database", f"{DATABASE}:database")
+    await ops_test.model.relate(f"{SLURMDBD}:database", f"{SLURMDBD}-{ROUTER}:database")
     # Reduce the update status frequency to accelerate the triggering of deferred events.
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(apps=[SLURMCTLD], status="active", timeout=1000)

--- a/tox.ini
+++ b/tox.ini
@@ -57,8 +57,7 @@ commands =
 description = Run integration tests
 deps =
     -r{toxinidir}/requirements.txt
-    juju==3.0.4
-    paramiko==2.12.0
+    juju==3.1.0.1
     pytest==7.2.0
     pytest_operator==0.23.0
     tenacity==8.1.0


### PR DESCRIPTION
## Description

* Switched to MySQL and MySQL router from Percona XtraDB cluster.
* Bumped Juju version to 3.1/stable.
* Removed unnecessary `paramiko` dependency from integration tox env.

## How was the code tested?

Updated integration tests where tested locally using my local LXD cloud with Juju via `tox -e integration`.

## Checklist

- [X] I am the author of these changes, or I have the rights to submit them.
- [X] I have added the relevant changes to the README and/or documentation.
- [X] I have self reviewed my own code.
- [x] All requested changes and/or review comments have been resolved.
