### PR TITLE
Add support for Ubuntu 22.04: part 1

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -2,8 +2,11 @@ type: charm
 bases:
   - build-on:
       - name: ubuntu
-        channel: "20.04"
+        channel: "22.04"
     run-on:
+      - name: ubuntu
+        channel: "22.04"
+        architectures: [amd64]
       - name: ubuntu
         channel: "20.04"
         architectures: [amd64]

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,33 +1,25 @@
 name: slurmctld
-
 summary: |
-    Slurmctld, the central management daemon of Slurm.
-
+  Slurmctld, the central management daemon of Slurm.
+description: |
+  This charm provides slurmctld, munged, and the bindings to other utilities
+  that make lifecycle operations a breeze.
+  
+  slurmctld is the central management daemon of SLURM. It monitors all other
+  SLURM daemons and resources, accepts work (jobs), and allocates resources
+  to those jobs.  Given the critical functionality of slurmctld, there may be
+  a backup server to assume these functions in the event that the primary
+  server fails.
+source: https://github.com/omnivector-solutions/slurmctld-operator
+issues: https://github.com/omnivector-solutions/slurmctld-operator/issues
 maintainers:
     - OmniVector Solutions <admin@omnivector.solutions>
-
-description: |
-    This charm provides slurmctld, munged, and the bindings to other utilities
-    that make lifecycle operations a breeze.
-
-    slurmctld is the central management daemon of SLURM. It monitors all other
-    SLURM daemons and resources, accepts work (jobs), and allocates resources
-    to those jobs.  Given the critical functionality of slurmctld, there may be
-    a backup server to assume these functions in the event that the primary
-    server fails.
-
-tags:
-    - slurm
-    - hpc
-
-series:
-    - focal
-    - centos7
+    - Jason C. Nucciarone <jason.nucciarone@canonical.com>
+    - David Gomez <david.gomez@canonical.com>
 
 peers:
   slurmctld-peer:
     interface: slurmctld-peer
-
 requires:
   slurmd:
     interface: slurmd
@@ -41,7 +33,6 @@ requires:
     interface: elasticsearch
   fluentbit:
     interface: fluentbit
-
 provides:
   prolog-epilog:
     interface: prolog-epilog
@@ -56,3 +47,6 @@ resources:
     description: >
       Official tarball containing the compiled etcd binaries. Retrieved from
       GitHub Releases.
+
+assumes:
+  - juju


### PR DESCRIPTION
## Description

Hey folks! This is part 1 of my work to upgrade the slurmctld-operator to support Ubuntu 22.04 (Jammy Jellyfish) as a base. This pull request mostly just contains metadata updates so that Juju does not fail when deploying slurmctld-operator to a 22.04 machine. Part 2 will contain the relevant integration test and CI pipeline updates. This pull request is mostly intended to make it so that I can pull "Jammified" SLURM charms from Charmhub for the integration tests.

Here are a couple of things that I changed in this pull request.

- Added me and David as maintainers in `metadata.yaml`. I felt that it would be good for us to be listed in maintainers so third-parties know who to contact about Canonical-licensed bits of code.
- Organized sections in `metadata.yaml`.
  - `tags` and `series` [are not supported options](https://juju.is/docs/sdk/metadata-yaml).  
- Added links for finding source code and issue tracker.
- Added assumes Juju so the charm is not accidentally deployed to a k8s charm.
- Added Ubuntu 22.04 to the `runs-on` section of `charmcraft.yaml`. Since slurmctld does not bundle platform-specific, dynamic binaries in the charm, we shouldn't need to have a separate builds on step too. etcd is a static binary so it should run on any base slurmctld is deployed to provided the base has the necessary dependency to run the static etcd binary. 

## How was the code tested?

I tested the code manually on my local machine due to Ubuntu 22.04 charms not being currently published to the edge channel on Charmhub.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
