### PR TITLE
Drop needs_reboot conditional in `_check_status(...)`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 *.py[cod]
 .idea
 .vscode/
+version

--- a/src/charm.py
+++ b/src/charm.py
@@ -24,7 +24,7 @@ from interface_slurmrestd import Slurmrestd
 from ops.charm import CharmBase, LeaderElectedEvent
 from ops.framework import StoredState
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, ModelError, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus, ModelError, WaitingStatus
 from slurm_ops_manager import SlurmManager
 
 logger = logging.getLogger()
@@ -349,17 +349,6 @@ class SlurmctldCharm(CharmBase):
         # NOTE: slurmd and slurmrestd are not needed for slurmctld to work,
         #       only for the cluster to operate. But we need slurmd inventory
         #       to assemble slurm.conf
-
-        if self._slurm_manager.needs_reboot:
-            self.unit.status = BlockedStatus("Machine needs reboot")
-            try:
-                self.unit.status = MaintenanceStatus("Rebooting...")
-                logger.debug("Scheduling machine reboot")
-                subprocess.run(["juju-reboot"], check=True)
-            except subprocess.CalledProcessError:
-                logger.error("Failed to schedule machine reboot")
-            return False
-
         if not self._stored.slurm_installed:
             self.unit.status = BlockedStatus("Error installing slurmctld")
             return False

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -160,18 +160,7 @@ class TestCharm(unittest.TestCase):
         self.harness.charm._stored.etcd_slurmd_pass = "test"
         self.assertEqual(self.harness.charm.etcd_slurmd_password, "test")
 
-    @patch("slurm_ops_manager.SlurmManager.needs_reboot", PropertyMock(return_value=True))
-    @patch("subprocess.run")
-    def test_check_status_needs_reboot(self, *_) -> None:
-        """Test that the check_status method works when the unit needs to be rebooted."""
-        res = self.harness.charm._check_status()
-        self.assertEqual(self.harness.charm.unit.status, MaintenanceStatus("Rebooting..."))
-        self.assertEqual(
-            res, False, msg="_check_status returned value True instead of expected value False."
-        )
-
-    @patch("slurm_ops_manager.SlurmManager.needs_reboot", PropertyMock(return_value=False))
-    def test_check_status_slurm_not_installed(self, *_) -> None:
+    def test_check_status_slurm_not_installed(self) -> None:
         """Test that the check_status method works when slurm is not installed."""
         self.harness.charm._stored.slurm_installed = False
         res = self.harness.charm._check_status()
@@ -182,9 +171,8 @@ class TestCharm(unittest.TestCase):
             res, False, msg="_check_status returned value True instead of expected value False."
         )
 
-    @patch("slurm_ops_manager.SlurmManager.needs_reboot", PropertyMock(return_value=False))
     @patch("slurm_ops_manager.SlurmManager.check_munged", return_value=False)
-    def test_check_status_bad_munge(self, *_) -> None:
+    def test_check_status_bad_munge(self, _) -> None:
         """Test that the check_status method works when munge encounters an error."""
         setattr(self.harness.charm._stored, "slurm_installed", True)  # Patch StoredState
         res = self.harness.charm._check_status()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -16,11 +16,11 @@
 """Test default charm events such as upgrade charm, install, etc."""
 
 import unittest
-from unittest.mock import PropertyMock, patch
+from unittest.mock import patch
 
 import ops.testing
 from charm import SlurmctldCharm
-from ops.model import BlockedStatus, MaintenanceStatus
+from ops.model import BlockedStatus
 from ops.testing import Harness
 
 ops.testing.SIMULATE_CAN_CONNECT = True

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -20,7 +20,7 @@ from unittest.mock import PropertyMock, patch
 
 import ops.testing
 from charm import SlurmctldCharm
-from ops.model import BlockedStatus
+from ops.model import BlockedStatus, MaintenanceStatus
 from ops.testing import Harness
 
 ops.testing.SIMULATE_CAN_CONNECT = True
@@ -161,10 +161,11 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(self.harness.charm.etcd_slurmd_password, "test")
 
     @patch("slurm_ops_manager.SlurmManager.needs_reboot", PropertyMock(return_value=True))
+    @patch("subprocess.run")
     def test_check_status_needs_reboot(self, *_) -> None:
         """Test that the check_status method works when the unit needs to be rebooted."""
         res = self.harness.charm._check_status()
-        self.assertEqual(self.harness.charm.unit.status, BlockedStatus("Machine needs reboot"))
+        self.assertEqual(self.harness.charm.unit.status, MaintenanceStatus("Rebooting..."))
         self.assertEqual(
             res, False, msg="_check_status returned value True instead of expected value False."
         )

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ deps =
     juju==3.1.0.1
     pytest==7.2.0
     pytest-operator==0.26.0
-    pytest-order=1.1.0
+    pytest-order==1.1.0
     tenacity==8.2.2
     -r{toxinidir}/requirements.txt
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -56,17 +56,16 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    -r{toxinidir}/requirements.txt
     juju==3.1.0.1
     pytest==7.2.0
-    pytest_operator==0.23.0
-    tenacity==8.1.0
+    pytest-operator==0.26.0
+    pytest-order=1.1.0
+    tenacity==8.2.2
+    -r{toxinidir}/requirements.txt
 commands =
     pytest -v \
-           -s \
-           --tb native \
-           --ignore={[vars]tst_path}unit \
-           --log-cli-level=INFO \
-           --model controller \
-           --keep-models \
-           {posargs}
+        -s \
+        --tb native \
+        --log-cli-level=INFO \
+        {[vars]tst_path}integration \
+        {posargs}


### PR DESCRIPTION
## Description

This pull request adds `juju-reboot` to the `_check_status(...)` function so that the machine will automatically restart if it needs security updates applied. Using `juju-reboot` helps with automatic deployments as a human-operator is not required to manually intervene when the slurmctld charm is first deployed.

One thing to note is that `_check_status(...)` is becoming too complex. The linter throws an error unless _# noqa C901_ is applied to the function. We should set some time aside to identify how we can simplify evaluating the current state of the slurmctld charm.

## How was the code tested?

I tested this charm on a private OpenStack instance with ubuntu@22.04 base images that needed security updates to be deployed.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
