### PR TITLE
Add support for using local charms in integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,34 +13,89 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Configure integration test run."""
+"""Configure slurmctld operator integration tests."""
 
-import pathlib
+import logging
+import os
+from pathlib import Path
+from typing import Union
 
 import pytest
 from helpers import NHC
 from pytest_operator.plugin import OpsTest
 
+logger = logging.getLogger(__name__)
+SLURMD_DIR = Path(os.getenv("SLURMD_DIR", "../slurmd-operator"))
+SLURMDBD_DIR = Path(os.getenv("SLURMDBD_DIR", "../slurmdbd-operator"))
+
 
 def pytest_addoption(parser) -> None:
     parser.addoption(
-        "--charm-base", action="store", default="ubuntu@22.04", help="Charm base to test."
+        "--charm-base",
+        action="store",
+        default="ubuntu@22.04",
+        help="Charm base version to use for integration tests",
+    )
+    parser.addoption(
+        "--use-local",
+        action="store_true",
+        default=False,
+        help="Use SLURM operators located on localhost rather than pull from Charmhub",
     )
 
 
 @pytest.fixture(scope="module")
 def charm_base(request) -> str:
     """Get slurmctld charm base to use."""
-    return request.config.getoption("--charm-base")
+    return request.config.option.charm_base
 
 
 @pytest.fixture(scope="module")
-async def slurmctld_charm(ops_test: OpsTest):
-    """Build slurmctld charm to use for integration tests."""
-    charm = await ops_test.build_charm(".")
-    return charm
+async def slurmctld_charm(ops_test: OpsTest) -> Path:
+    """Pack slurmctld charm to use for integration tests."""
+    return await ops_test.build_charm(".")
+
+
+@pytest.fixture(scope="module")
+async def slurmd_charm(request, ops_test: OpsTest) -> Union[str, Path]:
+    """Pack slurmd charm to use for integration tests when --use-local is specified.
+
+    Returns:
+        `str` "slurmd" if --use-local not specified or if SLURMD_DIR does not exist.
+    """
+    if request.config.option.use_local:
+        logger.info("Using local slurmd operator rather than pulling from Charmhub")
+        if SLURMD_DIR.exists():
+            return await ops_test.build_charm(SLURMD_DIR)
+        else:
+            logger.warning(
+                f"{SLURMD_DIR} not found. "
+                f"Defaulting to latest/edge slurmd operator from Charmhub"
+            )
+
+    return "slurmd"
+
+
+@pytest.fixture(scope="module")
+async def slurmdbd_charm(request, ops_test: OpsTest) -> Union[str, Path]:
+    """Pack slurmdbd charm to use for integration tests when --use-local is specified.
+
+    Returns:
+        `str` "slurmdbd" if --use-local not specified or if SLURMDBD_DIR does not exist.
+    """
+    if request.config.option.use_local:
+        logger.info("Using local slurmdbd operator rather than pulling from Charmhub")
+        if SLURMDBD_DIR.exists():
+            return await ops_test.build_charm(SLURMDBD_DIR)
+        else:
+            logger.warning(
+                f"{SLURMDBD_DIR} not found. "
+                f"Defaulting to latest/edge slurmdbd operator from Charmhub"
+            )
+
+    return "slurmdbd"
 
 
 def pytest_sessionfinish(session, exitstatus) -> None:
     """Clean up repository after test session has completed."""
-    pathlib.Path(NHC).unlink(missing_ok=True)
+    Path(NHC).unlink(missing_ok=True)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -15,7 +15,7 @@
 """Helpers for the slurmctld integration tests."""
 
 import logging
-import pathlib
+from pathlib import Path
 from typing import Dict
 from urllib import request
 
@@ -25,9 +25,9 @@ NHC = "lbnl-nhc-1.4.3.tar.gz"
 NHC_URL = f"https://github.com/mej/nhc/releases/download/1.4.3/{NHC}"
 
 
-def get_slurmd_res() -> Dict[str, pathlib.Path]:
+async def get_slurmd_res() -> Dict[str, Path]:
     """Get slurmd resources needed for charm deployment."""
-    if not (nhc := pathlib.Path(NHC)).exists():
+    if not (nhc := Path(NHC)).exists():
         logger.info(f"Getting resource {NHC} from {NHC_URL}")
         request.urlretrieve(NHC_URL, nhc)
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,8 @@ passenv =
     PYTHONPATH
     CHARM_BUILD_DIR
     MODEL_SETTINGS
+    SLURMD_DIR
+    SLURMDBD_DIR
 
 [testenv:fmt]
 description = Apply coding style standards to code
@@ -56,7 +58,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju==3.1.0.1
+    juju
     pytest==7.2.0
     pytest-operator==0.26.0
     pytest-order==1.1.0


### PR DESCRIPTION
## Description

Hey hey folks - this pull requests adds support for pulling local slurmdbd and slurmd operators into the integration tests for the slurmctld operator. I made couple changes to improve the timing of the local packing; all the charms are packed at the same time rather than in serial. I also made the function that fetches NHC a coroutine so it can run at the same time as the charms are being packed. To use local charms instead of the SLURM charms from Charmhub, you can using the following tox command:

```
tox run -e integration -- --use-local
```

The default directory path for the slurmdbd operator is `../slurmdbd-operator` and the default directory path for the slurmd operator is `../slurmd-operator`. They can be changed by setting the __SLURMD_DIR__ and __SLURMDBD_DIR__ environment variables for the tox environment in case you do have the SLURM operators stored in the same parent directory.

Now, for future, when we make changes to the SLURM charms that make them incompatible with the SLURM charms published to the store, we can tag the pull request as `Status: Testing Needed` to signify that we must run the tests locally before merging.

## How was the code tested?

I ran the updated integration tests using both my local copies of the slurmd and slurmdbd operators and using charms pull from Charmhub on my Ubuntu 23.04 Lunar Lobster laptop.

__Note:__ I did notice some odd particularities when using pylibjuju with IPv6 addresses. It seemed to have trouble parsing the addresses. May be a bug in pylibjuju, but I could not get the issue to consistently reproduce itself. _Something to keep an eye on..._ 

## Related issues and/or tasks

Closes #15 

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
