### PR TITLE
Update the slurm-ops-manager version in requirements.txt

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Can also be used for pull requests.
 
 * `Type: Idea Bank` - Issues that pertain to proposing potential improvement to slurmctld-operator.
 
-* `Type: Enchancement` - Issues marked as an agreed upon enhancement to slurmctld-operator. Can also be used for pull requests.
+* `Type: Enhancement` - Issues marked as an agreed upon enhancement to slurmctld-operator. Can also be used for pull requests.
 
 * `Statues: Help wanted` - Issues where we need help from the greater slurmctld-operator community to solve.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ops==2.*
 influxdb==5.3.1
 jinja2==3.1.2
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.12
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.16


### PR DESCRIPTION
## Description

Update the `slurm-ops-manager` to version 0.8.16 in the `requirements.txt` file to apply the changes to install Slurm 23.02 by default.

Obs.: This PR can only be merged after https://github.com/omnivector-solutions/slurm-ops-manager/pull/98 is merged and the release 0.8.16 is created for `slurm-ops-manager`.

## How was the code tested?

The code was tested locally and via the CI/CD workflow.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [x] All requested changes and/or review comments have been resolved.
